### PR TITLE
Fix layout and image widths

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -136,7 +136,7 @@ strong {
 img {
   position: relative;
   margin: 0 auto;
-  max-width: 739px;
+  max-width: 100%;
   padding: 5px;
   margin: 10px 0 10px 0;
   border: 1px solid #ebebeb;
@@ -264,7 +264,7 @@ Full-Width Styles
 
 .inner {
   position: relative;
-  max-width: 640px;
+  max-width: 768px;
   padding: 20px 10px;
   margin: 0 auto;
 }


### PR DESCRIPTION
The layout is presently not optimized for smaller screen widths - you get horizontal scrollbars. Additionally, a max-width of 640px is a bit small as some screenshots don't have the Brackets font size set to an increased value.
